### PR TITLE
[Feature]: Implement global exception handling with custom exceptions

### DIFF
--- a/apigateway/src/main/java/vaultweb/apigateway/exceptions/DefaultException.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/exceptions/DefaultException.java
@@ -1,59 +1,59 @@
 package vaultweb.apigateway.exceptions;
 
-import lombok.Getter;
 import vaultweb.apigateway.exceptions.dto.DefaultExceptionLevels;
+
+import lombok.Getter;
 
 @SuppressWarnings("unused")
 @Getter
 public class DefaultException extends Exception {
 
+  private final DefaultExceptionLevels level;
 
-    private final DefaultExceptionLevels level;
+  /**
+   * Constructs a new Default exception with the specified detail message.
+   *
+   * @param message the detail message
+   */
+  public DefaultException(String message) {
+    super(message);
+    this.level = DefaultExceptionLevels.DEFAULT_EXCEPTION; // default level
+  }
 
-    /**
-     * Constructs a new Default exception with the specified detail message.
-     *
-     * @param message the detail message
-     */
-    public DefaultException(String message) {
-        super(message);
-        this.level = DefaultExceptionLevels.DEFAULT_EXCEPTION; // default level
-    }
+  /**
+   * Constructs a new Default exception with the specified detail message and cause.
+   *
+   * @param message the detail message
+   * @param cause the cause of the exception
+   */
+  public DefaultException(String message, Throwable cause) {
+    super(message, cause);
+    this.level = DefaultExceptionLevels.DEFAULT_EXCEPTION; // default level
+  }
 
-    /**
-     * Constructs a new Default exception with the specified detail message and cause.
-     *
-     * @param message the detail message
-     * @param cause   the cause of the exception
-     */
-    public DefaultException(String message, Throwable cause) {
-        super(message, cause);
-        this.level = DefaultExceptionLevels.DEFAULT_EXCEPTION; // default level
-    }
+  /**
+   * Constructs a new Default exception with the specified cause.
+   *
+   * @param cause the cause of the exception
+   */
+  public DefaultException(Throwable cause) {
+    super(cause);
+    this.level = DefaultExceptionLevels.DEFAULT_EXCEPTION; // default level
+  }
 
-    /**
-     * Constructs a new Default exception with the specified cause.
-     *
-     * @param cause the cause of the exception
-     */
-    public DefaultException(Throwable cause) {
-        super(cause);
-        this.level = DefaultExceptionLevels.DEFAULT_EXCEPTION; // default level
-    }
+  /**
+   * Constructs a new Default exception with the specified message and level.
+   *
+   * @param message the detail message
+   * @param level the severity level of the exception
+   */
+  public DefaultException(String message, DefaultExceptionLevels level) {
+    super(message);
+    this.level = level;
+  }
 
-    /**
-     * Constructs a new Default exception with the specified message and level.
-     *
-     * @param message the detail message
-     * @param level   the severity level of the exception
-     */
-    public DefaultException(String message, DefaultExceptionLevels level) {
-        super(message);
-        this.level = level;
-    }
-
-    public DefaultException(String message, DefaultExceptionLevels level, Throwable cause) {
-        super(message, cause);
-        this.level = level;
-    }
+  public DefaultException(String message, DefaultExceptionLevels level, Throwable cause) {
+    super(message, cause);
+    this.level = level;
+  }
 }

--- a/apigateway/src/main/java/vaultweb/apigateway/exceptions/DefaultException.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/exceptions/DefaultException.java
@@ -1,0 +1,59 @@
+package vaultweb.apigateway.exceptions;
+
+import lombok.Getter;
+import vaultweb.apigateway.exceptions.dto.DefaultExceptionLevels;
+
+@SuppressWarnings("unused")
+@Getter
+public class DefaultException extends Exception {
+
+
+    private final DefaultExceptionLevels level;
+
+    /**
+     * Constructs a new Default exception with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public DefaultException(String message) {
+        super(message);
+        this.level = DefaultExceptionLevels.DEFAULT_EXCEPTION; // default level
+    }
+
+    /**
+     * Constructs a new Default exception with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the cause of the exception
+     */
+    public DefaultException(String message, Throwable cause) {
+        super(message, cause);
+        this.level = DefaultExceptionLevels.DEFAULT_EXCEPTION; // default level
+    }
+
+    /**
+     * Constructs a new Default exception with the specified cause.
+     *
+     * @param cause the cause of the exception
+     */
+    public DefaultException(Throwable cause) {
+        super(cause);
+        this.level = DefaultExceptionLevels.DEFAULT_EXCEPTION; // default level
+    }
+
+    /**
+     * Constructs a new Default exception with the specified message and level.
+     *
+     * @param message the detail message
+     * @param level   the severity level of the exception
+     */
+    public DefaultException(String message, DefaultExceptionLevels level) {
+        super(message);
+        this.level = level;
+    }
+
+    public DefaultException(String message, DefaultExceptionLevels level, Throwable cause) {
+        super(message, cause);
+        this.level = level;
+    }
+}

--- a/apigateway/src/main/java/vaultweb/apigateway/exceptions/GlobalExceptionHandler.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/exceptions/GlobalExceptionHandler.java
@@ -1,3 +1,97 @@
 package vaultweb.apigateway.exceptions;
 
-public class GlobalExceptionHandler {}
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import reactor.core.publisher.Mono;
+
+import java.sql.Timestamp;
+import java.util.stream.Collectors;
+
+/**
+ * Global exception handler for the API Gateway.
+ * Catches and processes various exceptions, returning appropriate HTTP responses.
+ *
+ * @author Calvin Shio
+ */
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(JsonProcessingException.class)
+    Mono<ResponseEntity<ErrorResponse>> handleJsonProcessing(JsonProcessingException ex, ServerHttpRequest request) {
+        log.error(ex.getMessage(), ex);
+        return Mono.just(ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(
+                        new ErrorResponse(
+                                ex.getOriginalMessage(),
+                                new Timestamp(System.currentTimeMillis()),
+                                request.getURI().getPath(),
+                                HttpStatus.BAD_REQUEST.toString()
+                        )
+                ));
+    }
+
+    @ExceptionHandler(DefaultException.class)
+    Mono<ResponseEntity<ErrorResponse>> handleDefaultException(DefaultException ex, ServerHttpRequest request) {
+        log.error(ex.getMessage(), ex);
+        return Mono.just(ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(
+                        new ErrorResponse(
+                                ex.getMessage(),
+                                new Timestamp(System.currentTimeMillis()),
+                                request.getURI().getPath(),
+                                HttpStatus.BAD_REQUEST.toString()
+                        )
+                ));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    Mono<ResponseEntity<ErrorResponse>> handleConstraintViolation(ConstraintViolationException ex, ServerHttpRequest request) {
+        log.error(ex.getMessage(), ex);
+        String message = ex.getConstraintViolations().stream()
+                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                .collect(Collectors.joining(", "));
+
+        return Mono.just(ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(
+                        new ErrorResponse(
+                                message,
+                                new Timestamp(System.currentTimeMillis()),
+                                request.getURI().getPath(),
+                                HttpStatus.BAD_REQUEST.toString()
+                        )
+                ));
+    }
+
+    @ExceptionHandler(Exception.class)
+    Mono<ResponseEntity<ErrorResponse>> handleGeneric(Exception ex, ServerHttpRequest request) {
+        log.error(ex.getMessage(), ex);
+        return Mono.just(ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(
+                        new ErrorResponse(
+                                ex.getMessage(),
+                                new Timestamp(System.currentTimeMillis()),
+                                request.getURI().getPath(),
+                                HttpStatus.INTERNAL_SERVER_ERROR.toString()
+                        )
+                ));
+    }
+
+    record ErrorResponse(
+            String message,
+            Timestamp timestamp,
+            String path,
+            String errorCode
+    ) {
+    }
+}

--- a/apigateway/src/main/java/vaultweb/apigateway/exceptions/GlobalExceptionHandler.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/exceptions/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import reactor.core.publisher.Mono;
+import vaultweb.apigateway.exceptions.dto.DefaultExceptionLevels;
 
 import java.sql.Timestamp;
 import java.util.stream.Collectors;
@@ -57,20 +58,16 @@ public class GlobalExceptionHandler {
     /**
      * Maps DefaultException level to appropriate HttpStatus.
      */
-    private HttpStatus mapExceptionLevelToHttpStatus(String level) {
+    private HttpStatus mapExceptionLevelToHttpStatus(DefaultExceptionLevels level) {
         if (level == null) {
             return HttpStatus.BAD_REQUEST;
         }
-        switch (level) {
-            case "AUTHENTICATION_EXCEPTION":
-                return HttpStatus.UNAUTHORIZED;
-            case "TIMEOUT_EXCEPTION":
-                return HttpStatus.GATEWAY_TIMEOUT;
-            case "HTTP_ERROR_EXCEPTION":
-                return HttpStatus.BAD_GATEWAY;
-            default:
-                return HttpStatus.BAD_REQUEST;
-        }
+        return switch (level) {
+            case DefaultExceptionLevels.AUTHENTICATION_EXCEPTION -> HttpStatus.UNAUTHORIZED;
+            case DefaultExceptionLevels.TIMEOUT_EXCEPTION -> HttpStatus.GATEWAY_TIMEOUT;
+            case DefaultExceptionLevels.HTTP_ERROR_EXCEPTION -> HttpStatus.BAD_GATEWAY;
+            default -> HttpStatus.BAD_REQUEST;
+        };
     }
     @ExceptionHandler(ConstraintViolationException.class)
     Mono<ResponseEntity<ErrorResponse>> handleConstraintViolation(ConstraintViolationException ex, ServerHttpRequest request) {

--- a/apigateway/src/main/java/vaultweb/apigateway/exceptions/GlobalExceptionHandler.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/exceptions/GlobalExceptionHandler.java
@@ -1,22 +1,25 @@
 package vaultweb.apigateway.exceptions;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import jakarta.validation.ConstraintViolationException;
-import lombok.extern.slf4j.Slf4j;
+import java.sql.Timestamp;
+import java.util.stream.Collectors;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import reactor.core.publisher.Mono;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import vaultweb.apigateway.exceptions.dto.DefaultExceptionLevels;
 
-import java.sql.Timestamp;
-import java.util.stream.Collectors;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
 
 /**
- * Global exception handler for the API Gateway.
- * Catches and processes various exceptions, returning appropriate HTTP responses.
+ * Global exception handler for the API Gateway. Catches and processes various exceptions, returning
+ * appropriate HTTP responses.
  *
  * @author Calvin Shio
  */
@@ -24,90 +27,79 @@ import java.util.stream.Collectors;
 @Slf4j
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(JsonProcessingException.class)
-    Mono<ResponseEntity<ErrorResponse>> handleJsonProcessing(JsonProcessingException ex, ServerHttpRequest request) {
-        log.error(ex.getMessage(), ex);
-        return Mono.just(ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(
-                        new ErrorResponse(
-                                ex.getOriginalMessage(),
-                                new Timestamp(System.currentTimeMillis()),
-                                request.getURI().getPath(),
-                                HttpStatus.BAD_REQUEST.toString()
-                        )
-                ));
-    }
+  @ExceptionHandler(JsonProcessingException.class)
+  Mono<ResponseEntity<ErrorResponse>> handleJsonProcessing(
+      JsonProcessingException ex, ServerHttpRequest request) {
+    log.error(ex.getMessage(), ex);
+    return Mono.just(
+        ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(
+                new ErrorResponse(
+                    ex.getOriginalMessage(),
+                    new Timestamp(System.currentTimeMillis()),
+                    request.getURI().getPath(),
+                    HttpStatus.BAD_REQUEST.toString())));
+  }
 
-    @ExceptionHandler(DefaultException.class)
-    Mono<ResponseEntity<ErrorResponse>> handleDefaultException(DefaultException ex, ServerHttpRequest request) {
-        log.error(ex.getMessage(), ex);
-        HttpStatus status = mapExceptionLevelToHttpStatus(ex.getLevel());
-        return Mono.just(ResponseEntity
-                .status(status)
-                .body(
-                        new ErrorResponse(
-                                ex.getMessage(),
-                                new Timestamp(System.currentTimeMillis()),
-                                request.getURI().getPath(),
-                                status.toString()
-                        )
-                ));
-    }
+  @ExceptionHandler(DefaultException.class)
+  Mono<ResponseEntity<ErrorResponse>> handleDefaultException(
+      DefaultException ex, ServerHttpRequest request) {
+    log.error(ex.getMessage(), ex);
+    HttpStatus status = mapExceptionLevelToHttpStatus(ex.getLevel());
+    return Mono.just(
+        ResponseEntity.status(status)
+            .body(
+                new ErrorResponse(
+                    ex.getMessage(),
+                    new Timestamp(System.currentTimeMillis()),
+                    request.getURI().getPath(),
+                    status.toString())));
+  }
 
-    /**
-     * Maps DefaultException level to appropriate HttpStatus.
-     */
-    private HttpStatus mapExceptionLevelToHttpStatus(DefaultExceptionLevels level) {
-        if (level == null) {
-            return HttpStatus.BAD_REQUEST;
-        }
-        return switch (level) {
-            case DefaultExceptionLevels.AUTHENTICATION_EXCEPTION -> HttpStatus.UNAUTHORIZED;
-            case DefaultExceptionLevels.TIMEOUT_EXCEPTION -> HttpStatus.GATEWAY_TIMEOUT;
-            case DefaultExceptionLevels.HTTP_ERROR_EXCEPTION -> HttpStatus.BAD_GATEWAY;
-            default -> HttpStatus.BAD_REQUEST;
-        };
+  /** Maps DefaultException level to appropriate HttpStatus. */
+  private HttpStatus mapExceptionLevelToHttpStatus(DefaultExceptionLevels level) {
+    if (level == null) {
+      return HttpStatus.BAD_REQUEST;
     }
-    @ExceptionHandler(ConstraintViolationException.class)
-    Mono<ResponseEntity<ErrorResponse>> handleConstraintViolation(ConstraintViolationException ex, ServerHttpRequest request) {
-        log.error(ex.getMessage(), ex);
-        String message = ex.getConstraintViolations().stream()
-                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
-                .collect(Collectors.joining(", "));
+    return switch (level) {
+      case DefaultExceptionLevels.AUTHENTICATION_EXCEPTION -> HttpStatus.UNAUTHORIZED;
+      case DefaultExceptionLevels.TIMEOUT_EXCEPTION -> HttpStatus.GATEWAY_TIMEOUT;
+      case DefaultExceptionLevels.HTTP_ERROR_EXCEPTION -> HttpStatus.BAD_GATEWAY;
+      default -> HttpStatus.BAD_REQUEST;
+    };
+  }
 
-        return Mono.just(ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(
-                        new ErrorResponse(
-                                message,
-                                new Timestamp(System.currentTimeMillis()),
-                                request.getURI().getPath(),
-                                HttpStatus.BAD_REQUEST.toString()
-                        )
-                ));
-    }
+  @ExceptionHandler(ConstraintViolationException.class)
+  Mono<ResponseEntity<ErrorResponse>> handleConstraintViolation(
+      ConstraintViolationException ex, ServerHttpRequest request) {
+    log.error(ex.getMessage(), ex);
+    String message =
+        ex.getConstraintViolations().stream()
+            .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+            .collect(Collectors.joining(", "));
 
-    @ExceptionHandler(Exception.class)
-    Mono<ResponseEntity<ErrorResponse>> handleGeneric(Exception ex, ServerHttpRequest request) {
-        log.error(ex.getMessage(), ex);
-        return Mono.just(ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(
-                        new ErrorResponse(
-                                ex.getMessage(),
-                                new Timestamp(System.currentTimeMillis()),
-                                request.getURI().getPath(),
-                                HttpStatus.INTERNAL_SERVER_ERROR.toString()
-                        )
-                ));
-    }
+    return Mono.just(
+        ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(
+                new ErrorResponse(
+                    message,
+                    new Timestamp(System.currentTimeMillis()),
+                    request.getURI().getPath(),
+                    HttpStatus.BAD_REQUEST.toString())));
+  }
 
-    record ErrorResponse(
-            String message,
-            Timestamp timestamp,
-            String path,
-            String errorCode
-    ) {
-    }
+  @ExceptionHandler(Exception.class)
+  Mono<ResponseEntity<ErrorResponse>> handleGeneric(Exception ex, ServerHttpRequest request) {
+    log.error(ex.getMessage(), ex);
+    return Mono.just(
+        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(
+                new ErrorResponse(
+                    ex.getMessage(),
+                    new Timestamp(System.currentTimeMillis()),
+                    request.getURI().getPath(),
+                    HttpStatus.INTERNAL_SERVER_ERROR.toString())));
+  }
+
+  record ErrorResponse(String message, Timestamp timestamp, String path, String errorCode) {}
 }

--- a/apigateway/src/main/java/vaultweb/apigateway/exceptions/dto/DefaultExceptionLevels.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/exceptions/dto/DefaultExceptionLevels.java
@@ -1,0 +1,19 @@
+package vaultweb.apigateway.exceptions.dto;
+
+/**
+ * Simple enum to represent different levels of exceptions that can occur
+ *
+ * @author Calvin Shio
+ */
+public enum DefaultExceptionLevels {
+    // On failure to get-access-tokens and verification
+    AUTHENTICATION_EXCEPTION,
+    // when the request to other services times out
+    TIMEOUT_EXCEPTION,
+    // when the request to other services fails with an HTTP error eg 404, 500, etc
+    HTTP_ERROR_EXCEPTION,
+    // when payload or response payload could not be parsed
+    PARSE_EXCEPTION,
+    // default exception for any other errors
+    DEFAULT_EXCEPTION,
+}

--- a/apigateway/src/main/java/vaultweb/apigateway/exceptions/dto/DefaultExceptionLevels.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/exceptions/dto/DefaultExceptionLevels.java
@@ -6,14 +6,14 @@ package vaultweb.apigateway.exceptions.dto;
  * @author Calvin Shio
  */
 public enum DefaultExceptionLevels {
-    // On failure to get-access-tokens and verification
-    AUTHENTICATION_EXCEPTION,
-    // when the request to other services times out
-    TIMEOUT_EXCEPTION,
-    // when the request to other services fails with an HTTP error eg 404, 500, etc
-    HTTP_ERROR_EXCEPTION,
-    // when payload or response payload could not be parsed
-    PARSE_EXCEPTION,
-    // default exception for any other errors
-    DEFAULT_EXCEPTION,
+  // On failure to get-access-tokens and verification
+  AUTHENTICATION_EXCEPTION,
+  // when the request to other services times out
+  TIMEOUT_EXCEPTION,
+  // when the request to other services fails with an HTTP error eg 404, 500, etc
+  HTTP_ERROR_EXCEPTION,
+  // when payload or response payload could not be parsed
+  PARSE_EXCEPTION,
+  // default exception for any other errors
+  DEFAULT_EXCEPTION,
 }


### PR DESCRIPTION
Resolves #14 — Add standardized error enum, error DTO and global exception handling
Add DefaultExceptionLevels enum to centralize common expected error categories (used to indicate severity/type of an error).
Add an API error wrapper DTO (fields: message, httpStatus, path/uri, level referencing DefaultExceptionLevels, plus optional errors for validation details) to standardize error payloads.
Update DefaultException to carry a DefaultExceptionLevels value.
Introduce a GlobalExceptionHandler (@ControllerAdvice) that converts exceptions into the error DTO and returns appropriate HTTP statuses; handles DefaultException, generic Exception, and Jakarta validation errors (MethodArgumentNotValidException / ConstraintViolationException) with structured validation messages.