### PR TITLE
test: add integration tests for authentication endpoints

### DIFF
--- a/apigateway/pom.xml
+++ b/apigateway/pom.xml
@@ -85,6 +85,16 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.r2dbc</groupId>
+			<artifactId>r2dbc-h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/apigateway/src/main/java/vaultweb/apigateway/exceptions/GlobalExceptionHandler.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/exceptions/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.support.WebExchangeBindException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -76,6 +77,24 @@ public class GlobalExceptionHandler {
     String message =
         ex.getConstraintViolations().stream()
             .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+            .collect(Collectors.joining(", "));
+
+    return Mono.just(
+        ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(
+                new ErrorResponse(
+                    message,
+                    new Timestamp(System.currentTimeMillis()),
+                    request.getURI().getPath(),
+                    HttpStatus.BAD_REQUEST.toString())));
+  }
+
+  @ExceptionHandler(WebExchangeBindException.class)
+  Mono<ResponseEntity<ErrorResponse>> handleValidation(
+      WebExchangeBindException ex, ServerHttpRequest request) {
+    String message =
+        ex.getFieldErrors().stream()
+            .map(error -> error.getField() + ": " + error.getDefaultMessage())
             .collect(Collectors.joining(", "));
 
     return Mono.just(

--- a/apigateway/src/main/java/vaultweb/apigateway/exceptions/GlobalExceptionHandler.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/exceptions/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.support.WebExchangeBindException;
@@ -92,10 +93,18 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(WebExchangeBindException.class)
   Mono<ResponseEntity<ErrorResponse>> handleValidation(
       WebExchangeBindException ex, ServerHttpRequest request) {
+    log.error(ex.getMessage(), ex);
     String message =
-        ex.getFieldErrors().stream()
-            .map(error -> error.getField() + ": " + error.getDefaultMessage())
+        ex.getAllErrors().stream()
+            .map(
+                error ->
+                    error instanceof FieldError fieldError
+                        ? fieldError.getField() + ": " + fieldError.getDefaultMessage()
+                        : error.getDefaultMessage())
             .collect(Collectors.joining(", "));
+    if (message.isBlank()) {
+      message = "Validation failed";
+    }
 
     return Mono.just(
         ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/apigateway/src/test/java/vaultweb/apigateway/controller/GatewayAuthControllerIntegrationTest.java
+++ b/apigateway/src/test/java/vaultweb/apigateway/controller/GatewayAuthControllerIntegrationTest.java
@@ -104,7 +104,19 @@ class GatewayAuthControllerIntegrationTest {
 
   @Test
   void register_withMissingName_isRejected() {
-    register("", "frank", "frank@example.com", VALID_PASSWORD).expectStatus().isBadRequest();
+    Map<String, String> bodyWithoutName = new HashMap<>();
+    bodyWithoutName.put("username", "frank");
+    bodyWithoutName.put("email", "frank@example.com");
+    bodyWithoutName.put("password", VALID_PASSWORD);
+
+    webTestClient
+        .post()
+        .uri("/auth/register")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(bodyWithoutName)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
   }
 
   // ----- /auth/login -----
@@ -149,7 +161,14 @@ class GatewayAuthControllerIntegrationTest {
 
   @Test
   void login_withMissingPassword_isRejected() {
-    login("someone@example.com", "").expectStatus().isBadRequest();
+    webTestClient
+        .post()
+        .uri("/auth/login")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(Map.of("emailUsername", "someone@example.com"))
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
   }
 
   // ----- /auth/refresh -----

--- a/apigateway/src/test/java/vaultweb/apigateway/controller/GatewayAuthControllerIntegrationTest.java
+++ b/apigateway/src/test/java/vaultweb/apigateway/controller/GatewayAuthControllerIntegrationTest.java
@@ -1,0 +1,191 @@
+package vaultweb.apigateway.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Integration tests for the public authentication endpoints exposed by {@link
+ * GatewayAuthController} ({@code /auth/register}, {@code /auth/login}, {@code /auth/refresh}). The
+ * gateway is started with a random port and backed by an in-memory R2DBC database so the full
+ * controller -&gt; service -&gt; repository path is exercised end to end.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+class GatewayAuthControllerIntegrationTest {
+
+  private static final String VALID_PASSWORD = "Test@1234";
+
+  @Autowired private WebTestClient webTestClient;
+
+  private static Map<String, String> registrationBody(
+      String name, String username, String email, String password) {
+    Map<String, String> body = new HashMap<>();
+    body.put("name", name);
+    body.put("username", username);
+    body.put("email", email);
+    body.put("password", password);
+    return body;
+  }
+
+  private WebTestClient.ResponseSpec register(
+      String name, String username, String email, String password) {
+    return webTestClient
+        .post()
+        .uri("/auth/register")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(registrationBody(name, username, email, password))
+        .exchange();
+  }
+
+  private WebTestClient.ResponseSpec login(String emailUsername, String password) {
+    return webTestClient
+        .post()
+        .uri("/auth/login")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(Map.of("emailUsername", emailUsername, "password", password))
+        .exchange();
+  }
+
+  // ----- /auth/register -----
+
+  @Test
+  void register_withValidPayload_returnsCreatedUserDetails() {
+    register("Alice", "alice", "alice@example.com", VALID_PASSWORD)
+        .expectStatus()
+        .isCreated()
+        .expectBody()
+        .jsonPath("$.username")
+        .isEqualTo("alice")
+        .jsonPath("$.email")
+        .isEqualTo("alice@example.com")
+        .jsonPath("$.name")
+        .isEqualTo("Alice")
+        .jsonPath("$.password")
+        .doesNotExist();
+  }
+
+  @Test
+  void register_withDuplicateEmail_isRejected() {
+    register("Bob", "bob", "dup-email@example.com", VALID_PASSWORD).expectStatus().isCreated();
+
+    register("Bobby", "bobby", "dup-email@example.com", VALID_PASSWORD)
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @Test
+  void register_withDuplicateUsername_isRejected() {
+    register("Carol", "carol", "carol@example.com", VALID_PASSWORD).expectStatus().isCreated();
+
+    register("Caroline", "carol", "carol2@example.com", VALID_PASSWORD)
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @Test
+  void register_withInvalidEmailFormat_isRejected() {
+    register("Dave", "dave", "not-an-email", VALID_PASSWORD).expectStatus().isBadRequest();
+  }
+
+  @Test
+  void register_withWeakPassword_isRejected() {
+    register("Erin", "erin", "erin@example.com", "weak").expectStatus().isBadRequest();
+  }
+
+  @Test
+  void register_withMissingName_isRejected() {
+    register("", "frank", "frank@example.com", VALID_PASSWORD).expectStatus().isBadRequest();
+  }
+
+  // ----- /auth/login -----
+
+  @Test
+  void login_withValidEmailCredentials_returnsTokens() {
+    register("Grace", "grace", "grace@example.com", VALID_PASSWORD).expectStatus().isCreated();
+
+    login("grace@example.com", VALID_PASSWORD)
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.accessToken")
+        .exists()
+        .jsonPath("$.refreshToken")
+        .exists();
+  }
+
+  @Test
+  void login_withValidUsernameCredentials_returnsTokens() {
+    register("Heidi", "heidi", "heidi@example.com", VALID_PASSWORD).expectStatus().isCreated();
+
+    login("heidi", VALID_PASSWORD)
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.accessToken")
+        .exists();
+  }
+
+  @Test
+  void login_withWrongPassword_isUnauthorized() {
+    register("Ivan", "ivan", "ivan@example.com", VALID_PASSWORD).expectStatus().isCreated();
+
+    login("ivan@example.com", "Wrong@1234").expectStatus().isUnauthorized();
+  }
+
+  @Test
+  void login_withNonExistentUser_isUnauthorized() {
+    login("ghost@example.com", VALID_PASSWORD).expectStatus().isUnauthorized();
+  }
+
+  @Test
+  void login_withMissingPassword_isRejected() {
+    login("someone@example.com", "").expectStatus().isBadRequest();
+  }
+
+  // ----- /auth/refresh -----
+
+  @Test
+  void refresh_withTokenFromLogin_returnsNewTokens() {
+    register("Judy", "judy", "judy@example.com", VALID_PASSWORD).expectStatus().isCreated();
+
+    byte[] loginResponse =
+        login("judy@example.com", VALID_PASSWORD)
+            .expectStatus()
+            .isOk()
+            .expectBody()
+            .returnResult()
+            .getResponseBody();
+
+    String refreshToken = readJsonField(loginResponse, "refreshToken");
+
+    webTestClient
+        .get()
+        .uri("/auth/refresh/{token}", refreshToken)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.accessToken")
+        .exists()
+        .jsonPath("$.refreshToken")
+        .exists();
+  }
+
+  private static String readJsonField(byte[] json, String field) {
+    try {
+      return new com.fasterxml.jackson.databind.ObjectMapper().readTree(json).get(field).asText();
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not read field '" + field + "' from response", e);
+    }
+  }
+}

--- a/apigateway/src/test/resources/application-test.yaml
+++ b/apigateway/src/test/resources/application-test.yaml
@@ -1,0 +1,9 @@
+spring:
+  r2dbc:
+    url: r2dbc:h2:mem:///auth_gateway_db?options=DB_CLOSE_DELAY=-1;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
+    username: sa
+    password:
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema.sql


### PR DESCRIPTION
## Summary

Adds integration tests for the public authentication endpoints (`/auth/register`, `/auth/login`, `/auth/refresh`), addressing #31. The gateway is started on a random port backed by an in-memory R2DBC (H2) database, so each test exercises the full controller → service → repository path end to end (no mocking of the data layer).

**Coverage (12 tests):**
- `register`: valid payload, duplicate email, duplicate username, invalid email format, weak password, missing field
- `login`: valid (by email and by username), wrong password, non-existent user, missing field
- `refresh`: round-trips a refresh token obtained from login

**Drive-by fix:** the new tests surfaced that request-validation failures (`WebExchangeBindException` from `@Valid` bodies) fell through to the generic handler and returned **500**. Added a handler so they now return **400** with the field messages, consistent with the existing `ConstraintViolationException` handling.

Verified locally with `mvn spotless:check test` → 13 tests pass.

Resolves #31.