### PR TITLE
Adding Change Username Endpoint

### DIFF
--- a/apigateway/src/main/java/vaultweb/apigateway/controller/GatewayAuthController.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/controller/GatewayAuthController.java
@@ -63,7 +63,7 @@ public class GatewayAuthController {
 
   @ResponseStatus(HttpStatus.OK)
   @PostMapping("change-username")
-  public Mono<Void> changeUsername(@Valid @RequestBody ChangeUsernameRequest request){
+  public Mono<Void> changeUsername(@Valid @RequestBody ChangeUsernameRequest request) {
     return authService.changeUsername(request);
   }
 

--- a/apigateway/src/main/java/vaultweb/apigateway/controller/GatewayAuthController.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/controller/GatewayAuthController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import vaultweb.apigateway.dto.request.ChangePasswordRequest;
+import vaultweb.apigateway.dto.request.ChangeUsernameRequest;
 import vaultweb.apigateway.dto.request.LoginRequest;
 import vaultweb.apigateway.dto.request.UserRegistrationRequest;
 import vaultweb.apigateway.dto.response.AuthResponse;
@@ -60,9 +61,10 @@ public class GatewayAuthController {
     return authService.logout();
   }
 
+  @ResponseStatus(HttpStatus.OK)
   @PostMapping("change-username")
-  public String changeUsername() {
-    return "changeUsername";
+  public Mono<Void> changeUsername(@Valid @RequestBody ChangeUsernameRequest request){
+    return authService.changeUsername(request);
   }
 
   @PostMapping("change-email")
@@ -70,6 +72,7 @@ public class GatewayAuthController {
     return "changeEmail";
   }
 
+  @ResponseStatus(HttpStatus.OK)
   @PostMapping("change-password")
   public Mono<Void> changePassword(@Valid @RequestBody ChangePasswordRequest request) {
     return authService.changePassword(request);

--- a/apigateway/src/main/java/vaultweb/apigateway/dto/request/ChangeUsernameRequest.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/dto/request/ChangeUsernameRequest.java
@@ -1,0 +1,7 @@
+package vaultweb.apigateway.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record ChangeUsernameRequest(
+    @NotEmpty(message = "Your new username is required") String newUsername
+) {}

--- a/apigateway/src/main/java/vaultweb/apigateway/dto/request/ChangeUsernameRequest.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/dto/request/ChangeUsernameRequest.java
@@ -3,5 +3,4 @@ package vaultweb.apigateway.dto.request;
 import jakarta.validation.constraints.NotEmpty;
 
 public record ChangeUsernameRequest(
-    @NotEmpty(message = "Your new username is required") String newUsername
-) {}
+    @NotEmpty(message = "Your new username is required") String newUsername) {}

--- a/apigateway/src/main/java/vaultweb/apigateway/service/auth/AuthService.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/service/auth/AuthService.java
@@ -143,8 +143,7 @@ public class AuthService {
               if (request.newUsername().equals(user.getUsername())) {
                 return Mono.error(
                     new DefaultException(
-                        "You didn't change anything",
-                        DefaultExceptionLevels.DEFAULT_EXCEPTION));
+                        "You didn't change anything", DefaultExceptionLevels.DEFAULT_EXCEPTION));
               }
 
               return userRepository

--- a/apigateway/src/main/java/vaultweb/apigateway/service/auth/AuthService.java
+++ b/apigateway/src/main/java/vaultweb/apigateway/service/auth/AuthService.java
@@ -3,6 +3,7 @@ package vaultweb.apigateway.service.auth;
 import org.springframework.stereotype.Service;
 
 import vaultweb.apigateway.dto.request.ChangePasswordRequest;
+import vaultweb.apigateway.dto.request.ChangeUsernameRequest;
 import vaultweb.apigateway.dto.request.LoginRequest;
 import vaultweb.apigateway.dto.request.UserRegistrationRequest;
 import vaultweb.apigateway.dto.response.AuthResponse;
@@ -125,6 +126,42 @@ public class AuthService {
               }
               user.setPassword(BcryptUtil.encode(request.newPassword()));
               return userRepository.save(user).then();
+            });
+  }
+
+  public Mono<Void> changeUsername(ChangeUsernameRequest request) {
+    return securityContextUtil
+        .getAuthenticatedUsername()
+        .flatMap(userRepository::findByUsername)
+        .switchIfEmpty(
+            Mono.error(
+                new DefaultException(
+                    "username from token has no registered user",
+                    DefaultExceptionLevels.AUTHENTICATION_EXCEPTION)))
+        .flatMap(
+            user -> {
+              if (request.newUsername().equals(user.getUsername())) {
+                return Mono.error(
+                    new DefaultException(
+                        "You didn't change anything",
+                        DefaultExceptionLevels.DEFAULT_EXCEPTION));
+              }
+
+              return userRepository
+                  .existsByUsername(request.newUsername())
+                  .flatMap(
+                      usernameExists -> {
+                        if (usernameExists) {
+                          return Mono.error(
+                              new DefaultException(
+                                  "User with username "
+                                      + request.newUsername()
+                                      + " already exists"));
+                        }
+
+                        user.setUsername(request.newUsername());
+                        return userRepository.save(user).then();
+                      });
             });
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: auth_gateway_db
     ports:
-      - "5433:5432"
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 


### PR DESCRIPTION
## Summary
Implements the `/auth/change-username` endpoint, one of the five
endpoints originally requested in #32. Follows the same pattern
established in the `/auth/change-password` PR: the current user is
resolved from the security context (not a client-supplied
identifier), the new username is validated for uniqueness before
being persisted, and a no-op request (new username identical to the
current one) is rejected explicitly.

## Linked issue
Closes #32 (partially — covers `change-username` only, as agreed
with @DenizAltunkapan; other endpoints to follow in separate PRs)

## How to test
1. `POST /auth/register` then `POST /auth/login` to obtain an access token
2. `POST /auth/change-username` with `Authorization: Bearer <token>`
   and `{ "newUsername": "..." }`
3. Verify:
   - missing/invalid token → 401
   - new username identical to current one → 400 ("You didn't change anything")
   - new username already taken by another user → 400 ("User with
     username ... already exists")
   - empty username → 400
   - successful change → 200, and a subsequent login with the old
     username fails while the new username succeeds

## Notes / Risk
No migrations or flags involved. Low risk: change is scoped to a
single new endpoint and its service method, no existing behavior
touched. Same non-blocking follow-up as the change-password PR
applies here too — refresh tokens aren't invalidated after a
username change; can be handled in a dedicated security-hardening
PR if desired.